### PR TITLE
Adjust Profile component to mobile view

### DIFF
--- a/frontend/src/components/Profile.js
+++ b/frontend/src/components/Profile.js
@@ -127,7 +127,7 @@ class Profile extends React.Component {
       <div className="profile-page">
         <div className="container">
           <div className="row p-4 text-center">
-            <div className="user-info col-xs-12 col-md-8 offset-md-2">
+            <div className="col-xs-12 col-md-8 offset-md-2">
               <img
                 src={profile.image}
                 className="user-img"


### PR DESCRIPTION
# Description

Adjust user profile page to mobile view by removing `user-info` class from profile image.

- Mobile view
![image](https://user-images.githubusercontent.com/48219965/175111405-71e703ac-376c-4aca-9596-747adb42a938.png)
- Desktop view 
![image](https://user-images.githubusercontent.com/48219965/175111492-d3109fa5-5d63-4328-9a95-5cf82b0f2699.png)


